### PR TITLE
Remove session changed check so SID cookie is always refreshed

### DIFF
--- a/src/session/SessionMiddleware.ts
+++ b/src/session/SessionMiddleware.ts
@@ -67,6 +67,7 @@ const sessionRequestHandler = (config: CookieConfig, sessionStore: SessionStore,
                         : DEFAULT_COOKIE_TIME_TO_LIVE_IN_SECONDS) * 1000,
                     encode: String
                 })
+                loggerInstance().debug(`Refreshed session cookie ${sessionCookie}`);
             } else {
                 if (sessionCookie) {
                     response.clearCookie(config.cookieName);

--- a/src/session/SessionMiddleware.ts
+++ b/src/session/SessionMiddleware.ts
@@ -58,17 +58,15 @@ const sessionRequestHandler = (config: CookieConfig, sessionStore: SessionStore,
 
         onHeaders(response, () => {
             if (request.session) {
-                if (hash(request.session) !== originalSessionHash) {
-                    response.cookie(config.cookieName, sessionCookie, {
-                        domain: config.cookieDomain,
-                        path: "/",
-                        httpOnly: true,
-                        secure: config.cookieSecureFlag != null ? config.cookieSecureFlag : DEFAULT_COOKIE_SECURE_FLAG,
-                        maxAge: (config.cookieTimeToLiveInSeconds != null ? config.cookieTimeToLiveInSeconds
-                            : DEFAULT_COOKIE_TIME_TO_LIVE_IN_SECONDS) * 1000,
-                        encode: String
-                    })
-                }
+                response.cookie(config.cookieName, sessionCookie, {
+                    domain: config.cookieDomain,
+                    path: "/",
+                    httpOnly: true,
+                    secure: config.cookieSecureFlag != null ? config.cookieSecureFlag : DEFAULT_COOKIE_SECURE_FLAG,
+                    maxAge: (config.cookieTimeToLiveInSeconds != null ? config.cookieTimeToLiveInSeconds
+                        : DEFAULT_COOKIE_TIME_TO_LIVE_IN_SECONDS) * 1000,
+                    encode: String
+                })
             } else {
                 if (sessionCookie) {
                     response.clearCookie(config.cookieName);

--- a/test/middleware/session-middleware.integration.test.ts
+++ b/test/middleware/session-middleware.integration.test.ts
@@ -142,7 +142,7 @@ describe("Session middleware - integration with express.js", () => {
                 })
 
                 // tslint:disable-next-line:max-line-length
-                it("should respond but not persist session nor reset session cookie if session load succeeded but session didn't change", async () => {
+                it("should respond but not persist session but reset session cookie if session load succeeded and session didn't change", async () => {
                     for (let createSessionWhenNotFound of [false, true]) {
                         const sessionStore: SubstituteOf<SessionStore> = Substitute.for<SessionStore>();
                         sessionStore.load(cookie).resolves(createSessionData(config.cookieSecret));
@@ -151,7 +151,10 @@ describe("Session middleware - integration with express.js", () => {
                             .get(uri)
                             .set("Cookie", [`${config.cookieName}=${cookie.value}`])
                             .expect(response => {
-                                expect(response.get("Set-Cookie")).to.be.equal(undefined)
+                                expect(response.get("Set-Cookie")[0]).to.be.satisfy((value: string) => {
+                                    return value.startsWith(`__SID=${cookie.value}; Max-Age=${config.cookieTimeToLiveInSeconds}; Domain=localhost; Path=/; Expires=`)
+                                        && value.endsWith("; HttpOnly; Secure")
+                                })
                                 validateResponse(response)
                             })
 


### PR DESCRIPTION
This pr removes a check in the node-session-handler that stops the refresh of the SID cookie if the session hasn't changed. This is so the session is refreshed on every request.

**Required for:**
- [BI-12511](https://companieshouse.atlassian.net/browse/BI-12511)

[BI-12511]: https://companieshouse.atlassian.net/browse/BI-12511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ