### PR TITLE
IDVA6-2510 - Add language support to node session handler

### DIFF
--- a/src/session/keys/SessionKey.ts
+++ b/src/session/keys/SessionKey.ts
@@ -9,5 +9,6 @@ export enum SessionKey {
     OAuth2Nonce = ".oauth2_nonce",
     ZXSKey = ".zxs_key",
     Pst = "pst",
-    CsrfToken = "csrf_token"
+    CsrfToken = "csrf_token",
+    Lang = "lang"
 }

--- a/src/session/model/Session.ts
+++ b/src/session/model/Session.ts
@@ -31,6 +31,15 @@ export class Session {
         return delete this.data[SessionKey.ExtraData][key];
     }
 
+    public getLanguage(): string | undefined {
+        return this.data[SessionKey.Lang];
+    }
+
+    public setLanguage(language: string): void {
+        // @ts-ignore - ignores read only flag to set language
+        this.data[SessionKey.Lang] = language;
+    }
+
     public verify (): void {
         const signInInfo = this.data[SessionKey.SignInInfo];
         if (signInInfo) {

--- a/src/session/model/SessionInterfaces.ts
+++ b/src/session/model/SessionInterfaces.ts
@@ -16,7 +16,8 @@ export type ISession = {
     [SessionKey.Pst]?: string,
     [SessionKey.SignInInfo]?: ISignInInfo,
     [SessionKey.ExtraData]?: any,
-    [SessionKey.CsrfToken]?: string
+    [SessionKey.CsrfToken]?: string,
+    [SessionKey.Lang]?: string
 };
 
 export type ISignInInfo = {

--- a/test/session/session.test.ts
+++ b/test/session/session.test.ts
@@ -39,6 +39,24 @@ describe("Session", () => {
         })
     });
 
+    describe("Session language", () => {
+        it("should get language when it exists", () => {
+            const session = new Session({ ...createSessionData(cookieSecret), [SessionKey.Lang]: "en" });
+            expect(session.getLanguage()).to.equal("en");
+        });
+
+        it("should return undefined when language does not exist", () => {
+            const session = new Session(createSessionData(cookieSecret));
+            expect(session.getLanguage()).to.equal(undefined);
+        });
+
+        it("should set language", () => {
+            const session = new Session(createSessionData(cookieSecret));
+            session.setLanguage("cy");
+            expect(session.getLanguage()).to.equal("cy");
+        });
+    });
+
     describe("session verification", () => {
         it("should pass and create verified session", () => {
             expect(() => createSession(cookieSecret).verify()).to.not.throw();


### PR DESCRIPTION
__Add getLanguage and setLanguage methods__

getLanguage and setLanguage methods were added to node-session-handler to provide access to the common language setting in the session for node services.

__JIRA Ticket Number__ : [2510](https://companieshouse.atlassian.net/jira/software/c/projects/SIV/boards/451?selectedIssue=IDVA6-2510)
